### PR TITLE
Optional buckets

### DIFF
--- a/project/version.sbt
+++ b/project/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.3.1-SNAPSHOT"


### PR DESCRIPTION
If you just want to use the `riffRaffArtifact` command and not upload anything, you shouldn't need to specify buckets. Unfortunately this does make for a backwards incompatible change for those already specifying buckets.
