### PR TITLE
Rename to sbt-riffraff-artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "riffraff-artifact"
+name := "sbt-riffraff-artifact"
 organization := "com.gu"
 
 sbtPlugin := true


### PR DESCRIPTION
The sbt- prefix is commonly used for plugins and also helps distinguish from the node alternative.
