### PR TITLE
Swap upload ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SBT plugin for creating [RiffRaff](https://github.com/guardian/deploy) deployabl
 
 Add
 ```
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.0")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.1")
 ```
 
 to your `project/plugins.sbt` and if you want to bundle your app as a `tgz` using 

--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -136,12 +136,12 @@ object RiffRaffArtifact extends AutoPlugin {
         }
 
         upload(
-          riffRaffUploadManifestBucket, riffRaffUploadManifestBucket.value,
-          riffRaffManifest, riffRaffManifest.value
-        )
-        upload(
           riffRaffUploadArtifactBucket, riffRaffUploadArtifactBucket.value,
           riffRaffArtifact, riffRaffArtifact.value
+        )
+        upload(
+          riffRaffUploadManifestBucket, riffRaffUploadManifestBucket.value,
+          riffRaffManifest, riffRaffManifest.value
         )
       }
     )


### PR DESCRIPTION
Firstly, this fix is a little speculative. But we've been [seeing issues](https://riffraff.gutools.co.uk/deployment/view/44d666e5-4ae6-48f7-9498-a857883fc446) where the riff raff project is continuously deploying, and reports an S3 404 because the artifact is missing.

Given that the build manifest is detected (and uploaded) first, the larger artifact upload may be too slow. So let's do the artifact upload first.

[update] Yep, riffraff continuous deployment works reliably with this change.
