### PR TITLE
Upload to <project name>/<build ID>/<filename> on S3

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -120,7 +120,7 @@ object RiffRaffArtifact extends AutoPlugin {
             
               val uploadRequest = new PutObjectRequest(
                 bucket,
-                s"${riffRaffPackageName.value}/${riffRaffBuildIdentifier.value}/${file.getName}",
+                s"${riffRaffManifestProjectName.value}/${riffRaffBuildIdentifier.value}/${file.getName}",
                 file)
       
               uploadRequest.withCannedAcl(CannedAccessControlList.BucketOwnerFullControl)


### PR DESCRIPTION
For both the artifacts bucket and metadata bucket, RiffRaff expects the top-level folder to be the project name, not the package name.

e.g. in [my project](https://github.com/guardian/bonobo/blob/master/build.sbt), package name == sbt project name == "bonobo", while manifest project name == "Content Platforms::bonobo::circleci".
sbt-riffraff-artifact mistakenly uploaded the artifact to `bonobo/...`, whereas RiffRaff looks for them in `Content Platforms::bonobo::circleci/...`.
