### PR TITLE
Tell users where their artifact is being uploaded to on S3

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -135,16 +135,14 @@ object RiffRaffArtifact extends AutoPlugin {
         ): Unit = {
           maybeBucket match {
             case Some(bucket) => {
-            
-              val uploadRequest = new PutObjectRequest(
-                bucket,
-                s"${riffRaffManifestProjectName.value}/${riffRaffBuildIdentifier.value}/${file.getName}",
-                file)
+
+              val uploadPathKey = s"${riffRaffManifestProjectName.value}/${riffRaffBuildIdentifier.value}/${file.getName}"
+              val uploadRequest = new PutObjectRequest(bucket, uploadPathKey, file)
       
               uploadRequest.withCannedAcl(CannedAccessControlList.BucketOwnerFullControl)
               client.putObject(uploadRequest)
               
-              streams.value.log.info(s"${fileTask.key.label} uploaded")
+              streams.value.log.info(s"${fileTask.key.label} uploaded to $uploadPathKey")
             }
             case None =>
               streams.value.log.warn(


### PR DESCRIPTION
I've configured a few RiffRaff deploys recently, and it struck me that knowing where your artifact was going in `riffraff-artifiact` was something I wanted to know - the old message is a bit gnomic:

![image](https://cloud.githubusercontent.com/assets/52038/16772085/b0b01870-484a-11e6-8518-70b876360511.png)

cc @philwills @aware 
