### PR TITLE
Add sbt-release configuration for releasing to bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,7 @@ organization := "com.gu"
 
 sbtPlugin := true
 
-enablePlugins(GitVersioning)
-
-scalaVersion := "2.10.4"
+scalaVersion := "2.10.6"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")
 
@@ -22,3 +20,21 @@ bintrayOrganization := Some("guardian")
 bintrayRepository := "sbt-plugins"
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+
+// Release
+import ReleaseTransformations._
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  publishArtifacts,
+  releaseStepTask(bintrayRelease),
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.8.5-SNAPSHOT"


### PR DESCRIPTION
This configuration was copied from the `sbt-release` plugin itself, which publishes to bintray: https://github.com/sbt/sbt-release/pull/110/commits/ddca176007aa25d36fe0369b3a52dbaf0c0de195

cc @philwills 
