### PR TITLE
Display S3 bucket name as well as path key to avoid confusion

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -135,14 +135,16 @@ object RiffRaffArtifact extends AutoPlugin {
         ): Unit = {
           maybeBucket match {
             case Some(bucket) => {
-
-              val uploadPathKey = s"${riffRaffManifestProjectName.value}/${riffRaffBuildIdentifier.value}/${file.getName}"
-              val uploadRequest = new PutObjectRequest(bucket, uploadPathKey, file)
+              val uploadRequest = new PutObjectRequest(
+                bucket,
+                s"${riffRaffManifestProjectName.value}/${riffRaffBuildIdentifier.value}/${file.getName}",
+                file
+              )
       
               uploadRequest.withCannedAcl(CannedAccessControlList.BucketOwnerFullControl)
               client.putObject(uploadRequest)
               
-              streams.value.log.info(s"${fileTask.key.label} uploaded to $uploadPathKey")
+              streams.value.log.info(s"${fileTask.key.label} uploaded to s3://${uploadRequest.getBucketName}/${uploadRequest.getKey}")
             }
             case None =>
               streams.value.log.warn(


### PR DESCRIPTION
I read `editorial-tools:explainer/24/artifacts.zip` to mean that the artifact had been uploaded into an `editorial-tools` bucket - but it did not! It was actually the first half of the first folder name in the
path - ie the first folder was called `editorial-tools:explainer`.

The new debug will show a full `s3://`-prefixed bucket name and path, to be clearer, ie:

```
s3://riffraff-artifact/editorial-tools:explainer/24/artifacts.zip
```

This follows on from https://github.com/guardian/sbt-riffraff-artifact/pull/21
