### PR TITLE
Teamcity needs the full path when publishing artifacts

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -111,7 +111,7 @@ object RiffRaffArtifact extends AutoPlugin {
     lazy val defaultSettings = coreSettings ++ Seq(
       riffRaffNotifyTeamcity := {
           riffRaffArtifactResources.value.foreach { case (file, target) =>
-            println(s"##teamcity[publishArtifacts '${file.getName} => ${riffRaffArtifactPublishPath.value}/$target']")
+            println(s"##teamcity[publishArtifacts '$file => ${riffRaffArtifactPublishPath.value}/$target']")
           }
       },
 


### PR DESCRIPTION
When trying to convert riff-raff over to use the new format I've discovered that the publishArtifact doesn't give the full path. This simply doesn't work. I've not tested this change in TC, but am hopeful that this will solve the issue.

Before:

```
##teamcity[publishArtifacts 'riff-raff.tgz => ./packages/riff-raff/riff-raff.tgz']
##teamcity[publishArtifacts 'deploy.json => ./deploy.json']
```

After:

```
##teamcity[publishArtifacts '/Users/shildrew/working/riff-raff/riff-raff/target/universal/riff-raff.tgz => ./packages/riff-raff/riff-raff.tgz']
##teamcity[publishArtifacts '/Users/shildrew/working/riff-raff/riff-raff/conf/deploy.json => ./deploy.json']
```
