### PR TITLE
Second attempt to fix the teamcity notify task

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -110,9 +110,15 @@ object RiffRaffArtifact extends AutoPlugin {
 
     lazy val defaultSettings = coreSettings ++ Seq(
       riffRaffNotifyTeamcity := {
-          riffRaffArtifactResources.value.foreach { case (file, target) =>
-            println(s"##teamcity[publishArtifacts '$file => ${riffRaffArtifactPublishPath.value}/$target']")
-          }
+        val teamcityPublishDirectory = target.value / riffRaffArtifactDirectory.value / "teamcity"
+        IO.delete(teamcityPublishDirectory)
+
+        riffRaffArtifactResources.value.foreach { case (file, targetName) =>
+          val targetFile = teamcityPublishDirectory / targetName
+          IO.copyFile(file, targetFile)
+        }
+
+        println(s"##teamcity[publishArtifacts '$teamcityPublishDirectory => .']")
       },
 
       riffRaffUpload := {


### PR DESCRIPTION
This is a second attempt to fix the notify task for teamcity. We should phase it out, but this should still work.

There is no way of mapping to a target artifact so we have to collect the files we want and then publish the content of the directory.
