### PR TITLE
adds teamcity usage to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ can upload to those buckets resolvable by the [DefaultAWSCredentialsProviderChai
 AWS_SECRET_ACCESS_KEY environment variables. Travis has [instructions](http://docs.travis-ci.com/user/environment-variables/#Encrypting-Variables-Using-a-Public-Key) 
 on how to encrypt these variables.
 
+**TeamCity Usage**
+
+Set the riffRaffBuildIdentifier with:
+```scala
+riffRaffBuildIdentifier := env("BUILD_NUMBER").getOrElse("DEV")
+```
+
+TeamCity copies the directory over without git info and so will fail. One fix is to specify the value explicitly:
+```scala
+riffRaffManifestVcsUrl := "git@github.com:guardian/repo-name.git"
+```
+
 Customisation
 -------------
 


### PR DESCRIPTION
TeamCity checks out on the server then copies the directory over without git info and so latest version of sbt-riffraff-artifact wont work. #18 

This PR updates the readme to:
- give riffraffBuildIdentifier needed for TeamCity (existing example uses Travis)
- explain need to explicitly add `riffRaffManifestVcsUrl`

Another workaround suggested by @philwills  was to change settings in TeamCity: 

> set the VCS checkout mode in the build setting in Teamcity to be Automatically on agent

But I couldn't get this to work:

> Error while applying patch: Failed to perform checkout on agent: TeamCity doesn't support authentication method 'Private Key' with agent checkout. Please use different authentication method.

So, not adding to readme.
