### PR TITLE
Team city integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ If you want to bundle your app as a `tgz` using
 enablePlugins(RiffRaffArtifact, UniversalPlugin)
 
 riffRaffPackageType := (packageZipTarball in Universal).value
-
-def env(key: String): Option[String] = Option(System.getenv(key))
-riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 ```
@@ -42,14 +39,22 @@ on how to encrypt these variables.
 
 **TeamCity Usage**
 
-Set the riffRaffBuildIdentifier with:
+The plugin should support teamcity by default. A standard assembly configuration looks like
 ```scala
-riffRaffBuildIdentifier := env("BUILD_NUMBER").getOrElse("DEV")
+enablePlugins(RiffRaffArtifact)
+
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
 ```
 
-TeamCity copies the directory over without git info and so will fail. One fix is to specify the value explicitly:
+And a standard native packager configuration looks like
 ```scala
-riffRaffManifestVcsUrl := "git@github.com:guardian/repo-name.git"
+enablePlugins(RiffRaffArtifact)
+
+riffRaffPackageType := (packageZipTarball in Universal).value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
 ```
 
 Customisation

--- a/README.md
+++ b/README.md
@@ -37,25 +37,6 @@ can upload to those buckets resolvable by the [DefaultAWSCredentialsProviderChai
 AWS_SECRET_ACCESS_KEY environment variables. Travis has [instructions](http://docs.travis-ci.com/user/environment-variables/#Encrypting-Variables-Using-a-Public-Key) 
 on how to encrypt these variables.
 
-**TeamCity Usage**
-
-The plugin should support teamcity by default. A standard assembly configuration looks like
-```scala
-enablePlugins(RiffRaffArtifact)
-
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-```
-
-And a standard native packager configuration looks like
-```scala
-enablePlugins(RiffRaffArtifact)
-
-riffRaffPackageType := (packageZipTarball in Universal).value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-```
 
 Customisation
 -------------

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ packageDescription := """Slightly longer description"""
 
 riffRaffPackageType := (packageBin in Debian).value
 
-riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 ```
@@ -97,7 +96,6 @@ enablePlugins(RiffRaffArtifact)
 
 riffRaffPackageType := assembly.value
 
-riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -5,14 +5,13 @@ sbtPlugin := true
 
 scalaVersion := "2.10.6"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4")
-
 libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.7" % "provided",
   "com.lihaoyi" %% "upickle" % "0.3.4",
   "org.scalamacros" %% s"quasiquotes" % "2.0.0" % "provided",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.5.1"
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.5.1",
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.5.0.201609210915-r"
 )
 
 publishMavenStyle := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -1,0 +1,68 @@
+package com.gu.riffraff.artifact
+
+import java.io.File
+
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+
+import scala.util.Try
+
+
+case class BuildInfo(
+  buildIdentifier: String,
+  branch: String,
+  revision: String,
+  url: String
+) {
+  override def toString(): String =
+    s"""
+       |Build identifier = $buildIdentifier
+       |Branch = $branch
+       |Revision = $revision
+       |Url = $url
+     """.stripMargin
+}
+
+object BuildInfo {
+
+  val unknown = BuildInfo(
+    buildIdentifier = "unknown",
+    branch = "unknown",
+    revision = "unknown",
+    url = "unknown"
+  )
+
+  def git(baseDirectory: File): Option[BuildInfo] = {
+    val baseRepo = new FileRepositoryBuilder().findGitDir(baseDirectory)
+    baseRepo.setMustExist(true)
+
+    for {
+      repo <- Try(baseRepo.build()).toOption
+      branch <- Option(repo.getBranch)
+      url <- Option(repo.getConfig.getString("remote", "origin", "url"))
+      revision = Try(ObjectId.toString(repo.resolve("HEAD"))).toOption.getOrElse("unknown")
+    } yield BuildInfo(
+      buildIdentifier = "unknown",
+      branch = branch,
+      revision = revision,
+      url = url
+    )
+  }
+
+  def teamCity: Option[BuildInfo] = {
+    def prop(propName: String): Option[String] = Option(System.getProperty(propName))
+    for {
+      buildIdentifier <- prop("build.number")
+      revision <- prop("build.vcs.number")
+      branch <- prop("vcsroot.branch")
+      url <- prop("vcsroot.url")
+    } yield BuildInfo(
+      buildIdentifier = buildIdentifier,
+      branch = branch,
+      revision = revision,
+      url = url
+    )
+  }
+
+  def apply(baseDirectory: File): BuildInfo = git(baseDirectory) orElse teamCity getOrElse unknown
+}

--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -33,6 +33,7 @@ object BuildInfo {
   )
 
   def git(baseDirectory: File): Option[BuildInfo] = {
+    def env(propName: String): Option[String] = Option(System.getenv(propName))
     val baseRepo = new FileRepositoryBuilder().findGitDir(baseDirectory)
     baseRepo.setMustExist(true)
 
@@ -42,7 +43,7 @@ object BuildInfo {
       url <- Option(repo.getConfig.getString("remote", "origin", "url"))
       revision = Try(ObjectId.toString(repo.resolve("HEAD"))).toOption.getOrElse("unknown")
     } yield BuildInfo(
-      buildIdentifier = "unknown",
+      buildIdentifier = env("TRAVIS_BUILD_NUMBER") getOrElse "unknown",
       branch = branch,
       revision = revision,
       url = url


### PR DESCRIPTION
This is an attempt to fix the empty branch problem we see when pushing artefacts to riff-raff from team-city.

It turns out teamcity should passes all we need to create our build. I haven't had the chance to test it on a TC instance, suggestions welcome as I have no clue how to do that without releasing.

_I got rid of sbt-git. I think a lot of people rely on `sbt-riffraff`'s transiant dependency to be able to type git commands directly from an sbt session. So it may raise one or two eyebrows after the upgrade_

@philwills @rtyley @sihil 