### PR TITLE
Make upload dependent on tests

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -145,7 +145,9 @@ object RiffRaffArtifact extends AutoPlugin {
           riffRaffUploadManifestBucket, riffRaffUploadManifestBucket.value,
           riffRaffManifest, prefix, riffRaffManifest.value
         )(client, streams.value)
-      }
+      },
+
+      riffRaffUpload := (riffRaffUpload dependsOn (test in Test)).value
     )
 
     lazy val legacySettings = coreSettings ++ Seq(
@@ -182,7 +184,9 @@ object RiffRaffArtifact extends AutoPlugin {
           riffRaffUploadManifestBucket, riffRaffUploadManifestBucket.value,
           riffRaffManifest, prefix, riffRaffManifest.value
         )(client, streams.value)
-      }
+      },
+
+      riffRaffUpload := (riffRaffUpload dependsOn (test in Test)).value
     )
   }
 


### PR DESCRIPTION
A couple of projects had to manually redefine tasks to avoid uploading the artefact if the tests were failing.

I think it makes sense to force that library to depend on successful tests.

I have tested it with an empty project with one failing / succeeding test.

let me know what you think.

cc @TBonnin and @davidfurey  as you have experienced that problem