### PR TITLE
use a different approach to get the branch name

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -52,7 +52,12 @@ object BuildInfo {
 
   def teamCity: Option[BuildInfo] = {
 
-    def prop(propName: String, props: Properties = System.getProperties): Option[String] = Option(props.getProperty(propName))
+    def prop(propName: String, props: Properties = System.getProperties): Option[String] = {
+      Option(props.getProperty(propName))
+        .map(_.trim)
+        .filter(_.nonEmpty)
+    }
+
     def loadProps(file: String): Option[Properties] = {
       try {
         val props = new Properties()

--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -70,12 +70,17 @@ object BuildInfo {
       }
     }
 
+    def tcBranch(tcProps: Properties): Option[String] = {
+      lazy val fromVcsRoot = prop("vcsroot.branch", tcProps).map(ref => ref.split("/").lastOption.getOrElse(ref))
+      prop("teamcity.build.branch", tcProps).orElse(fromVcsRoot)
+    }
+
     for {
       tcPropFile <- prop("teamcity.configuration.properties.file")
       tcProps <- loadProps(tcPropFile)
       buildIdentifier <- prop("build.number", tcProps)
       revision <- prop("build.vcs.number", tcProps)
-      branch <- prop("vcsroot.branch", tcProps).map(ref => ref.split("/").lastOption.getOrElse(ref))
+      branch <- tcBranch(tcProps)
       url <- prop("vcsroot.url", tcProps)
     } yield BuildInfo(
       buildIdentifier = buildIdentifier,

--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -70,7 +70,7 @@ object BuildInfo {
       tcProps <- loadProps(tcPropFile)
       buildIdentifier <- prop("build.number", tcProps)
       revision <- prop("build.vcs.number", tcProps)
-      branch <- prop("teamcity.build.branch", tcProps)
+      branch <- prop("vcsroot.branch", tcProps).map(ref => ref.split("/").lastOption.getOrElse(ref))
       url <- prop("vcsroot.url", tcProps)
     } yield BuildInfo(
       buildIdentifier = buildIdentifier,


### PR DESCRIPTION
It turns out the `teamcity.build.branch` property is only set when a branch specification is set in the configuration.
This is not the case by default, however another property is always set: `vcsroot.branch`
`vcsroot.branch` is in the git format `refs/heads/master` hence the parsing attempt, with a conservative fallback