### PR TITLE
add the possibility to add a directory as a package

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -1,5 +1,7 @@
 package com.gu.riffraff.artifact
 
+import java.io.File
+
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client}
 import com.amazonaws.services.s3.model.{CannedAccessControlList, PutObjectRequest}
 import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
@@ -82,7 +84,20 @@ object RiffRaffArtifact extends AutoPlugin {
       riffRaffArtifactResources := {
         val configFileName = if (riffRaffUseYamlConfig.value) "riff-raff.yaml" else "deploy.json"
         val packagePathPrefix = if (riffRaffUseYamlConfig.value) "" else "packages/"
-        Seq(
+
+        val rrPackageType = riffRaffPackageType.value
+        val rrPackageName = riffRaffPackageName.value
+
+        val packageFiles: Seq[(File, String)] = if (rrPackageType.isDirectory) {
+          staticPackage(rrPackageType)
+        } else {
+          Seq(
+            rrPackageType ->
+            s"$packagePathPrefix$rrPackageName/${rrPackageType.getName}"
+          )
+        }
+
+        packageFiles ++ Seq(
           // systemd unit
           baseDirectory.value / s"${riffRaffPackageName.value}.service" ->
             s"$packagePathPrefix${riffRaffPackageName.value}/${riffRaffPackageName.value}.service",
@@ -91,14 +106,10 @@ object RiffRaffArtifact extends AutoPlugin {
           baseDirectory.value / s"${riffRaffPackageName.value}.conf" ->
             s"$packagePathPrefix${riffRaffPackageName.value}/${riffRaffPackageName.value}.conf",
 
-          // compressed redistributable
-          riffRaffPackageType.value ->
-            s"$packagePathPrefix${riffRaffPackageName.value}/${riffRaffPackageType.value.getName}",
-
           // deploy instructions
           (resourceDirectory in Compile).value / configFileName -> configFileName,
           baseDirectory.value / configFileName -> configFileName
-        ).filter { case (file, _) => file.exists }
+        ).distinct.filter { case (file, _) => file.exists }
       },
 
       riffRaffManifest := {
@@ -188,6 +199,22 @@ object RiffRaffArtifact extends AutoPlugin {
 
       riffRaffUpload := (riffRaffUpload dependsOn (test in Test)).value
     )
+
+    def staticPackage(packageDirectory: File): Seq[(File, String)] = {
+      def listRegularFiles(file: File): Seq[File] = {
+        if (file.isDirectory) {
+          file.listFiles().toSeq.flatMap(listRegularFiles)
+        } else {
+          Seq(file)
+        }
+      }
+
+      val dir = packageDirectory.getAbsoluteFile.toPath.getParent
+
+      listRegularFiles(packageDirectory).map { file =>
+        file -> dir.relativize(file.getAbsoluteFile.toPath).toString
+      }
+    }
   }
 
   def upload(bucketSetting: SettingKey[Option[String]], maybeBucket: Option[String],


### PR DESCRIPTION
This is to handle cases where one of the modules is a list of static files.

Mapi has one [example here](https://github.com/guardian/mobile-apps-api/blob/MSS-84-amigo/build.sbt#L106), and that would avoid my workaround