### PR TITLE
cross-sbt release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ sbtPlugin := true
 scalaVersion := "2.12.3"
 sbtVersion in Global := "1.0.0"
 crossSbtVersions := Seq("1.0.0", "0.13.16")
+releaseCrossBuild := true
+
 scalaCompilerBridgeSource := {
   val sv = appConfiguration.value.provider.id.version
   ("org.scala-sbt" % "compiler-interface" % sv % "component").sources


### PR DESCRIPTION
according to [this thread](https://github.com/sbt/sbt-release/issues/206) the `releaseCrossBuild` flag should enable sbt-release to publish for the two sbt versions.

But it's hard to test without actually releasing.