### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Continuous integration
 
 You can configure your continuous integration system (Teamcity and alike) by running the following task:
 ```scala
-sbt clean test riffRaffUpload
+sbt clean riffRaffUpload
 ```
 
+The `riffRaffUpload` task will execute the tests in your project, and then upload the artifacts and manifest.
 
 Customisation
 -------------


### PR DESCRIPTION
The current documentation was possibly misleading:
```
sbt clean test riffRaffUpload
```
implies that `riffRaffUpload` doesn't run the tests in the project, whereas actually it does.

As an side:

- does `riffRaffUpload` need to be dependent on the `test` task? 
- I'm not sure if this dependency means that the upload will happen only if the tests are successful e.g. from a recent build log of the [payment-api](https://github.com/guardian/payment-api) in Team City:
    ```
    ...
    [17:01:30] Publishing internal artifacts
    [17:01:31] About to upload artifacts to S3
    [17:01:31] Artifact S3 upload complete
    [17:01:31] 11 failed tests detected
    [17:01:31] Build finished
    ```
