### PR TITLE
Bump AWS and remove deps to avoid an IllegalStateException

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,15 +16,12 @@ libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.7" % "provided",
   "com.lihaoyi" %% "upickle" % "0.4.4",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.5.1",
-  "org.eclipse.jgit" % "org.eclipse.jgit" % "4.5.0.201609210915-r",
-  "org.apache.httpcomponents" % "httpclient" % "4.5.3+",
-  "com.jcraft" % "jsch" % "0.1.54+",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.10",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.368",
+  "org.eclipse.jgit" % "org.eclipse.jgit" % "5.0.1.201806211838-r",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.2", // bump to remove vulnerable version pulled in by AWS
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
   "org.scalamock" %% "scalamock" % "4.0.0" % "test"
-
 )
 
 fork in Test := false


### PR DESCRIPTION
`1.15` broke my build - seemingly due to a conflict between AWS and the Apache http client.

This tidies it up and will hopefully fix the issue.