### PR TITLE
Use the environment envs instead of system properties

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -119,12 +119,14 @@ object BuildInfo {
     }
 
     for {
-      tcPropFile <- prop("teamcity.configuration.properties.file")
-      tcProps <- loadProps(tcPropFile)
-      buildIdentifier <- prop("build.number", tcProps)
-      revision <- prop("build.vcs.number", tcProps)
-      branch <- prop("teamcity.build.branch", tcProps) orElse vcsRootBranch(tcProps)
-      url <- prop("vcsroot.url", tcProps)
+      tcBuildPropsFile <- env("TEAMCITY_BUILD_PROPERTIES_FILE")
+      tcBuildProps <- loadProps(tcBuildPropsFile)
+      tcConfigPropFile <- prop("teamcity.configuration.properties.file", tcBuildProps)
+      tcConfigProps <- loadProps(tcConfigPropFile)
+      buildIdentifier <- prop("build.number", tcConfigProps)
+      revision <- prop("build.vcs.number", tcConfigProps)
+      branch <- prop("teamcity.build.branch", tcConfigProps) orElse vcsRootBranch(tcConfigProps)
+      url <- prop("vcsroot.url", tcConfigProps)
     } yield BuildInfo(
       buildIdentifier = buildIdentifier,
       branch = branch,


### PR DESCRIPTION
The current version of the plugin bootstraps the TC info from a system property that is only present when using the a build runner or passing through a system property. This tweaks the logic to work from an environment variable which is also available when using the command line runner.

Not tested in anger, but have run through the logic by hand on a running TC server.