### PR TITLE
add a comment around magical syntax

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -123,6 +123,7 @@ object RiffRaffArtifact extends AutoPlugin {
           IO.copyFile(file, targetFile)
         }
 
+        // see https://www.jetbrains.com/help/teamcity/service-messages.html#Publishing+Artifacts+while+the+Build+is+Still+in+Progress
         println(s"##teamcity[publishArtifacts '$teamcityPublishDirectory => .']")
       },
 
@@ -159,6 +160,7 @@ object RiffRaffArtifact extends AutoPlugin {
       riffRaffArtifactFile := "artifacts.zip",
 
       riffRaffNotifyTeamcity := {
+        // see https://www.jetbrains.com/help/teamcity/service-messages.html#Publishing+Artifacts+while+the+Build+is+Still+in+Progress
         println(s"##teamcity[publishArtifacts '${riffRaffArtifact.value} => ${riffRaffArtifactPublishPath.value}']")
       },
 


### PR DESCRIPTION
It's not immediately obvious why we're `println`-ing `##`. This adds a comment, linking to docs that provide more information.