### PR TITLE
correct docs to reference correct version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 
 Add
 ```scala
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 ```
 
 to your `project/plugins.sbt`


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Correct docs to reference correct version number.

This also serves as a way to validate the CI performance gains introduced in https://github.com/guardian/sbt-riffraff-artifact/pull/53. If the first CI execution on this branch is fast (below ~1min) caching is working! Else if it takes ~3mins then it's not (3mins was the duration of the build prior to caching being added, [source](https://github.com/guardian/sbt-riffraff-artifact/actions/runs/294982561)).