### PR TITLE
Migrate plugin to maven central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea
+.bsp

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 SBT plugin for creating [RiffRaff](https://github.com/guardian/deploy) deployable artifacts 
 ===========================================================================================
 
-[![Build Status](https://travis-ci.org/guardian/sbt-riffraff-artifact.svg?branch=master)](https://travis-ci.org/guardian/sbt-riffraff-artifact)
-[ ![Download](https://api.bintray.com/packages/guardian/sbt-plugins/sbt-riffraff-artifact/images/download.svg) ](https://bintray.com/guardian/sbt-plugins/sbt-riffraff-artifact/_latestVersion)
+![Build status](https://github.com/guardian/sbt-riffraff-artifact/actions/workflows/ci.yml/badge.svg?branch=master)
+[ ![Download](https://maven-badges.herokuapp.com/maven-central/com.gu/sbt-riffraff-artifact/badge.svg) ](https://search.maven.org/artifact/com.gu/sbt-riffraff-artifact)
 
 Installation
 ------------
 
 Add
 ```scala
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12") // use latest version from above
 ```
 
 to your `project/plugins.sbt`

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
 
 fork in Test := false
 
-publishMavenStyle := false
+publishMavenStyle := true
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 scmInfo := Some(ScmInfo(url("https://github.com/guardian/sbt-riffraff-artifact"), "scm:git@github.com:guardian/sbt-riffraff-artifact"))

--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,6 @@ scalaVersion := "2.12.3"
 sbtVersion in Global := "1.0.0"
 crossSbtVersions := Seq("1.0.0", "0.13.16")
 
-scalaCompilerBridgeSource := {
-  val sv = appConfiguration.value.provider.id.version
-  ("org.scala-sbt" % "compiler-interface" % sv % "component").sources
-}
-
 libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.7" % "provided",
@@ -27,14 +22,16 @@ libraryDependencies ++= Seq(
 fork in Test := false
 
 publishMavenStyle := false
-bintrayOrganization := Some("guardian")
-bintrayRepository := "sbt-plugins"
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+scmInfo := Some(ScmInfo(url("https://github.com/guardian/sbt-riffraff-artifact"), "scm:git@github.com:guardian/sbt-riffraff-artifact"))
+homepage := scmInfo.value.map(_.browseUrl)
+developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))
 
 // Release
 import ReleaseTransformations._
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
+publishTo := sonatypePublishToBundle.value
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -44,7 +41,7 @@ releaseProcess := Seq[ReleaseStep](
   commitReleaseVersion,
   tagRelease,
   releaseStepCommandAndRemaining("^ publishSigned"),
-  releaseStepTask(bintrayRelease),
+  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
   pushChanges

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,3 @@
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
-
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.12-SNAPSHOT"
+version in ThisBuild := "1.1.12"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.10"
+version in ThisBuild := "1.1.11-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.12"
+version in ThisBuild := "1.1.13-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.11"
+version in ThisBuild := "1.1.12-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.11-SNAPSHOT"
+version in ThisBuild := "1.1.11"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.10-SNAPSHOT"
+version in ThisBuild := "1.1.10"


### PR DESCRIPTION
## What does this change?
As of 28th February, [no more submissions will be accepted to Bintray & JCenter](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/), and downloads from BinTray will end as of 1st May 2021 (see also [Eugene Yokota](https://twitter.com/eed3si9n)'s [tweets](https://twitter.com/eed3si9n/status/1357387938577924100) about this):

> To streamline the productivity of the JFrog Platform we will be sunsetting Bintray (including JCenter), GoCenter, and ChartCenter services on May 1st, 2021. Users of these services will need to migrate to the **respective canonical repository**, and we will continue to offer both [free and paid JFrog Platform cloud subscriptions](https://jfrog.com/pricing/#sass) that can serve other binary distribution needs.

> After this date end users should retrieve artifacts from the canonical repo (e.g. Java packages would be retrieved from Maven Central).

This PR moves this plugin to OSS Sonatype. It's worth noting that sbt-plugins on the shared `sbt-plugins` repo will be migrated to a sponsored repo but it is unclear if we are able to publish new versions to this - see https://github.com/sbt/sbt/issues/6294.

The badge on the readme is also updated to show the version on Maven Central.

This closes #55.

This PR also takes the opportunity to change the badge from TravisCI to point to GHA.

## How to test
As part of doing this work version 1.1.11 was published to Maven (you can see this in the commit history, which also includes the fate of 1.1.10). Testing this plugin's new home can be done by bumping to to 1.1.11 on a project of your choosing. This has already been tested on Prism.

## How can we measure success?
We are able to ship updates to this plugin after bintray is sunset regardless of anything else happening.