### PR TITLE
Add support for GitHub Actions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.7" % "provided",
   "com.lihaoyi" %% "upickle" % "0.4.4",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.368",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.1034",
   "org.eclipse.jgit" % "org.eclipse.jgit" % "5.0.1.201806211838-r",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.2", // bump to remove vulnerable version pulled in by AWS
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",

--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -135,6 +135,26 @@ object BuildInfo {
     )
   }
 
+  def gitHubActions: Option[BuildInfo] = {
+    for {
+      runNumber <- env("GITHUB_RUN_NUMBER")
+      sha <- env("GITHUB_SHA")
+      ref <- env("GITHUB_REF")
+      baseUrl <- env("GITHUB_SERVER_URL")
+      repo <- env("GITHUB_REPOSITORY")
+    } yield BuildInfo(
+      buildIdentifier = runNumber,
+      branch = ref,
+      revision = sha,
+      url = s"$baseUrl/$repo"
+    )
+  }
+
   def apply(baseDirectory: File): BuildInfo =
-    teamCity orElse circleCi orElse travis orElse git(baseDirectory) getOrElse unknown
+    teamCity orElse
+      gitHubActions orElse
+      circleCi orElse
+      travis orElse
+      git(baseDirectory) getOrElse
+      unknown
 }


### PR DESCRIPTION
## What does this change?
Provides support for uploading to RiffRaff from GitHub Actions.

Two things were needed:
 - bump the AWS library so we have support for JWT based credential providers
 - add a new BuildInfo generator that works inside GHA

## How to test
Switch a project over to use the latest version in GHA

## How can we measure success?
We unlock GHA as a CI target with RiffRaff