### PR TITLE
fix: Add `aws-java-sdk-sts` as explicit dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,14 @@ scalaVersion := "2.12.3"
 sbtVersion in Global := "1.0.0"
 crossSbtVersions := Seq("1.0.0", "0.13.16")
 
+val awsVersion = "1.11.1034"
+
 libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.8.1",
   "org.joda" % "joda-convert" % "1.7" % "provided",
   "com.lihaoyi" %% "upickle" % "0.4.4",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.1034",
+  "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
+  "com.amazonaws" % "aws-java-sdk-sts" % awsVersion, // to enable use of `WebIdentityTokenCredentialsProvider` in the credential provider chain
   "org.eclipse.jgit" % "org.eclipse.jgit" % "5.0.1.201806211838-r",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.2", // bump to remove vulnerable version pulled in by AWS
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This is to allow the use of `WebIdentityTokenCredentialsProvider` within GitHub Actions.

With https://github.com/guardian/actions-assume-aws-role we've unlocked the ability to use GHA for CI.

The blocker has previously been gaining AWS credentials.

https://github.com/guardian/actions-assume-aws-role allows GHA to assume a role to gain permissions to upload to Riff-Raff's buckets.

When trying to [migrate a repository](https://github.com/guardian/prism/runs/3655992308?check_suite_focus=true) to GHA, we're greeted with this:

```
WebIdentityTokenCredentialsProvider: To use assume role profiles the aws-java-sdk-sts module must be on the class path.
```

Add `aws-java-sdk-sts` as explicit dependency to resolve.