### PR TITLE
fix: Use `GITHUB_HEAD_REF` in favour of `GITHUB_REF` if available

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -139,7 +139,12 @@ object BuildInfo {
     for {
       runNumber <- env("GITHUB_RUN_NUMBER")
       sha <- env("GITHUB_SHA")
-      ref <- env("GITHUB_REF")
+
+      // `GITHUB_HEAD_REF` is only set for pull request events and represents the branch name (e.g. `feature-branch-1`).
+      // `GITHUB_REF` is the branch or tag ref that triggered the workflow (e.g. `refs/heads/feature-branch-1` or `refs/pull/259/merge`).
+      // See https://docs.github.com/en/actions/learn-github-actions/environment-variables
+      ref <- env("GITHUB_HEAD_REF").orElse(env("GITHUB_REF"))
+
       baseUrl <- env("GITHUB_SERVER_URL")
       repo <- env("GITHUB_REPOSITORY")
     } yield BuildInfo(


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

`GITHUB_HEAD_REF` is only set for pull request events and represents the branch name (e.g. `feature-branch-1`).

`GITHUB_REF` is the branch or tag ref that triggered the workflow (e.g. `refs/heads/feature-branch-1` or `refs/pull/259/merge`).

Using `GITHUB_HEAD_REF` at first provides a more human readable value. Sadly it's not always set so fallback to `GITHUB_REF`.

See https://docs.github.com/en/actions/learn-github-actions/environment-variables
