### PR TITLE
fix: Sanitise the default branch name in GHA

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -141,7 +141,7 @@ object BuildInfo {
       sha <- env("GITHUB_SHA")
 
       // `GITHUB_HEAD_REF` is only set for pull request events and represents the branch name (e.g. `feature-branch-1`).
-      // `GITHUB_REF` is the branch or tag ref that triggered the workflow (e.g. `refs/heads/feature-branch-1` or `refs/pull/259/merge`).
+      // `GITHUB_REF` is the branch or tag ref that triggered the workflow (e.g. `refs/heads/feature-branch-1` or `refs/pull/259/merge` or `refs/heads/main`).
       // See https://docs.github.com/en/actions/learn-github-actions/environment-variables
       ref <- env("GITHUB_HEAD_REF").orElse(env("GITHUB_REF"))
 
@@ -149,7 +149,7 @@ object BuildInfo {
       repo <- env("GITHUB_REPOSITORY")
     } yield BuildInfo(
       buildIdentifier = runNumber,
-      branch = ref,
+      branch = ref.stripPrefix("refs/heads/"),
       revision = sha,
       url = s"$baseUrl/$repo"
     )


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Upon merging into the default branch, the value of `GITHUB_REF` is `"refs/heads/main"`. Sanitise this for consistency.

https://github.com/guardian/node-riffraff-artifact/pull/30 is the node equivalent.