### PR TITLE
fix: Add bucket name defaults

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -67,8 +67,10 @@ object RiffRaffArtifact extends AutoPlugin {
       riffRaffManifestFile := "build.json",
       riffRaffBuildInfo := BuildInfo(baseDirectory.value),
 
-      riffRaffUploadArtifactBucket := None,
-      riffRaffUploadManifestBucket := None,
+      // The following are defaults for the Guardian
+      riffRaffUploadArtifactBucket := Some("riffraff-artifact"),
+      riffRaffUploadManifestBucket := Some("riffraff-builds"),
+
       riffRaffAddManifestDir := None,
 
       riffRaffUseYamlConfig := (baseDirectory.value / "riff-raff.yaml").exists || ((resourceDirectory in Compile).value / "riff-raff.yaml").exists,


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Default the values for:
  - `riffRaffUploadArtifactBucket`
  - `riffRaffUploadManifestBucket`

This will help reduce the amount of config needed in a project's `build.sbt`.

The default values only apply for the Guardian; add a note to that effect.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

DRYer `build.sbt`s.