### PR TITLE
fix: Improve branch lookup from GitHub Actions

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
@@ -26,7 +26,10 @@ case class BuildInfo(
 object BuildInfo {
 
   val UNKNOWN = "unknown"
+  val UNKNOWN_BRANCH = "unknown-branch"
+
   def env(propName: String): Option[String] = sys.env.get(propName)
+  def envNonEmpty(propName: String): Option[String] = sys.env.get(propName).filter(_.trim.nonEmpty)
 
   val unknown = BuildInfo(
     buildIdentifier = UNKNOWN,
@@ -57,9 +60,9 @@ object BuildInfo {
     // TRAVIS_BRANCH is master when building PRs
     def getTravisBranch: Option[String] = {
       env("TRAVIS_PULL_REQUEST") match {
-        case Some("false") => env("TRAVIS_BRANCH").orElse(Some("unknown-branch"))
+        case Some("false") => env("TRAVIS_BRANCH").orElse(Some(UNKNOWN_BRANCH))
         case Some(i) => Some(s"pr/$i")
-        case None => Some("unknown-branch")
+        case None => Some(UNKNOWN_BRANCH)
       }
     }
 
@@ -142,8 +145,9 @@ object BuildInfo {
 
       // `GITHUB_HEAD_REF` is only set for pull request events and represents the branch name (e.g. `feature-branch-1`).
       // `GITHUB_REF` is the branch or tag ref that triggered the workflow (e.g. `refs/heads/feature-branch-1` or `refs/pull/259/merge` or `refs/heads/main`).
+      // Either can be the empty string ¯\_(ツ)_/¯
       // See https://docs.github.com/en/actions/learn-github-actions/environment-variables
-      ref <- env("GITHUB_HEAD_REF").orElse(env("GITHUB_REF"))
+      ref <- envNonEmpty("GITHUB_HEAD_REF").orElse(envNonEmpty("GITHUB_REF")).orElse(Some(UNKNOWN_BRANCH))
 
       baseUrl <- env("GITHUB_SERVER_URL")
       repo <- env("GITHUB_REPOSITORY")


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The branch name within a GitHub Actions environment can be in one of two places:
  - `GITHUB_HEAD_REF` during PR builds
  - `GITHUB_REF` during a build

We read `GITHUB_HEAD_REF` and fallback to `GITHUB_REF`.

Either can be the empty string which is not very useful, especially as Riff-Raff uses branch names for continuous and scheduled deployment.

This change guards against this possibility by checking an env var isn't empty and defaults to `"unknown-branch"`.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Unit tests would be nice. Would require a bit of refactoring; we'd want to be able to pass in a map of values when in test and use env vars otherwise. I'll commit to doing this should we need to revisit this code again.
