### PR TITLE
Add a composite GitHub Action for use in CI downstream

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,39 @@
+# A composite GitHub Action, performing CI for `sbt-riffraff-artifact`.
+# See https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
+
+name: CI for sbt-riffraff-artifact
+description: CI for projects using sbt-riffraff-artifact
+inputs:
+  riffRaffRoleArn:
+    description: 'ARN of the role with permission to upload to the Riff-Raff buckets'
+    required: true
+  finalTeamCityBuildNumber:
+    description: 'If migrating from TeamCity, the number of the final build to ensure continuity within Riff-Raff'
+    default: '0'
+    required: false
+  javaVersion:
+    description: 'Which java version to use'
+    default: '8'
+    required: false
+  javaDistribution:
+    description: 'Which java distribution to use'
+    default: 'adopt'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - uses: guardian/actions-assume-aws-role@v1
+      with:
+        awsRoleToAssume: ${{ inputs.riffRaffRoleArn }}
+    - name: Set up JDK
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ inputs.javaVersion }}
+        distribution: ${{ inputs.javaDistribution }}
+    - name: CI for sbt-riffraff-artifact
+      shell: bash
+      env:
+        FINAL_TEAMCITY_BUILD: ${{ inputs.finalTeamCityBuildNumber }}
+      run: |
+        export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $FINAL_TEAMCITY_BUILD ))
+        sbt clean compile test riffRaffUpload


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[Composite Actions](https://github.blog/changelog/2020-08-07-github-actions-composite-run-steps/) allow us to simplify workflows, specifically by encapsulating logic in a single place for use elsewhere.

GitHub Actions doesn't have access to Riff-Raff's buckets by default, access needs to be granted via [`guardian/actions-assume-aws-role`](https://github.com/guardian/actions-assume-aws-role). This change adds a composite action which uses `guardian/actions-assume-aws-role`, removing boilerplate from downstream repositories as usage becomes:

```yaml
- uses: guardian/sbt-riffraff-artifact@aa-composite-action
  with:
    riffRaffRoleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
```

See https://github.com/guardian/cdk-playground/pull/111 for an example.

We can later combine this with [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) to simplify CI of repositories even further.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See above linked example PR, it should pass CI and have an artifact available for Riff-Raff to deploy.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

DRYer GHA for CI definitions in repositories.