### PR TITLE
Fetching AWS region as a task rather than a setting

### DIFF
--- a/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
+++ b/src/main/scala/com/gu/riffraff/artifact/RiffRaffArtifact.scala
@@ -29,7 +29,7 @@ object RiffRaffArtifact extends AutoPlugin {
 
     lazy val riffRaffAwsCredentialsProfile = settingKey[Option[String]]("AWS credentials profile used to upload to S3")
     lazy val riffRaffCredentialsProvider = settingKey[AWSCredentialsProvider]("AWS Credentials provider used to upload to S3")
-    lazy val riffRaffAwsRegion = settingKey[String]("AWS region used to connect to S3")
+    lazy val riffRaffAwsRegion = taskKey[String]("AWS region used to connect to S3")
 
     lazy val riffRaffManifest = taskKey[File]("Creates a file representing a build for RiffRaff to consume")
 


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This changes the riffRaffAwsRegion used for making S3 requests to be a task, rather than a setting. We observed that this setting was generating warnings on sbt startup on consuming projects. That is because the request to `Regions.getRegion` makes a network request which when made locally is expected to fail. There is no need for this request to be made until `riffRaffUpload` is run, but IIUC making it a setting means that it will always be executed on startup.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
I've published locally and the start up warning is no longer present.  I've also done a dummy run of `riffRaffUpload` and the warning was generated there (which is perhaps useful?) and the task failed at the expected stage (S3 upload, as I intentionally had invalid credentials).

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Consuming projects should not have unnecessary warnings, or make unnecessary network requests

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
There's a risk I haven't tested this fully (i.e. riffRaffUpload on TC or GHA) but I think it's easiest to publish and then fix if necessary, as it is quite a simple change. I'm not sure if it's worth publishing a snapshot version just to test that.